### PR TITLE
cmd/findlink: Print out the URL links from HTML document

### DIFF
--- a/cmd/findlink/main.go
+++ b/cmd/findlink/main.go
@@ -1,0 +1,35 @@
+// findlink finds the link from the HTML DOM and print out the links
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/net/html"
+)
+
+func main() {
+	docs, err := html.Parse(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "HTML document parse error: %v", err)
+		os.Exit(1)
+	}
+	for _, link := range visit(nil, docs) {
+		fmt.Println(link)
+	}
+}
+
+// visit visits DOM nodes in breadth-first search and returns list of URLs.
+func visit(links []string, n *html.Node) []string {
+	if n.Type == html.ElementNode && n.Data == "a" {
+		for _, a := range n.Attr {
+			if a.Key == "href" {
+				links = append(links, a.Val)
+			}
+		}
+	}
+	for c := range n.ChildNodes() {
+		links = visit(links, c)
+	}
+	return links
+}

--- a/cmd/findlink/main.go
+++ b/cmd/findlink/main.go
@@ -19,7 +19,7 @@ func main() {
 	}
 }
 
-// visit visits DOM nodes in breadth-first search and returns list of URLs.
+// visit visits DOM nodes in depth-first search and returns list of URLs.
 func visit(links []string, n *html.Node) []string {
 	if n.Type == html.ElementNode && n.Data == "a" {
 		for _, a := range n.Attr {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/keithnoguchi/crawl-go
 
 go 1.23.4
+
+require golang.org/x/net v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=


### PR DESCRIPTION
It takes the UTF-8 encoded HTML document from the standard input
and search through the URL links with the depth-first approach.