### PR TITLE
cmd/tagoutline: It outlines the HTML DOM elements indented

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Language][gopl].
 - [outline][] outlines the HTML DOM elements.
 - [fetchlinks][] fetches and show found links, e.g. fetch | findlink
 - [waitserver][] waits for the server reachability
+- [tagoutline][] outlines the HTML DOM elements indented.
 
 Happy hacking!
 
@@ -21,3 +22,4 @@ Happy hacking!
 [outline]: ./cmd/outline/main.go
 [fetchlinks]: ./cmd/fetchlinks/main.go
 [waitserver]: ./cmd/waitserver/main.go
+[tagoutline]: ./cmd/tagoutline/main.go

--- a/cmd/tagoutline/main.go
+++ b/cmd/tagoutline/main.go
@@ -1,0 +1,31 @@
+// tagoutline outlines the HTML DOM element indented.
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"golang.org/x/net/html"
+)
+
+func main() {
+	log.SetPrefix("tagoutline ")
+	log.SetFlags(0)
+	for _, url := range os.Args[1:] {
+		_, err := fetch(url)
+		if err != nil {
+			log.Printf("fetch: %v\n", err)
+			continue
+		}
+	}
+}
+
+func fetch(url string) (*html.Node, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return nil, nil
+}


### PR DESCRIPTION
It utilizes the generic depth first traversal function, pkg/traversal.DepthFirstTraversal.